### PR TITLE
Required arguments as hints

### DIFF
--- a/beaker/application.py
+++ b/beaker/application.py
@@ -135,6 +135,16 @@ class Application:
             optimize=OptimizeOptions(scratch_slots=True),
         )
 
+    def contract_hints(self):
+        hints = {}
+        for name, attr in self.attrs.items():
+            hc = get_handler_config(attr)
+            h = hc.hints()
+            if len(h.keys()) > 0:
+                hints[name] = h
+
+        return hints
+
     def initialize_app_state(self):
         return self.app_state.initialize()
 

--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -15,7 +15,7 @@ from algosdk.logic import get_application_address
 from algosdk.v2client.algod import AlgodClient
 
 from beaker.application import Application, method_spec
-from beaker.decorators import HandlerFunc
+from beaker.decorators import HandlerFunc, get_handler_config
 
 # TODO make const
 APP_MAX_PAGE_SIZE = 2048
@@ -25,6 +25,9 @@ class ApplicationClient:
     def __init__(self, client: AlgodClient, app: Application, app_id: int = 0):
         self.client = client
         self.app = app
+        self.hints = self.app.contract_hints()
+
+        # Also set in create
         self.app_id = app_id
 
     def compile(self) -> tuple[bytes, bytes]:
@@ -155,6 +158,9 @@ class ApplicationClient:
 
         if not isinstance(method, abi.Method):
             method = method_spec(method)
+
+        if method.name in self.hints:
+            print(f"Did you do the thing?: {self.hints[method.name]}")
 
         if sp is None:
             sp = self.client.suggested_params()

--- a/beaker/contracts/op_up.py
+++ b/beaker/contracts/op_up.py
@@ -4,7 +4,7 @@ from pyteal import *
 from beaker.application import Application
 from beaker.application_schema import GlobalStateValue
 from beaker.consts import Algo
-from beaker.decorators import internal, handler
+from beaker.decorators import internal, required_args, handler
 
 
 OpUpTarget = Return(Txn.sender() == Global.creator_address())
@@ -19,6 +19,10 @@ class OpUp(Application):
     opup_app_id: Final[GlobalStateValue] = GlobalStateValue(
         stack_type=TealType.uint64, key=Bytes("ouaid"), static=True
     )
+
+    @handler(read_only=True)
+    def get_opup_app_id(*, output: abi.Uint64):
+        return output.set(OpUp.opup_app_id)
 
     @internal(TealType.none)
     def create_opup():

--- a/beaker/decorators.py
+++ b/beaker/decorators.py
@@ -49,7 +49,7 @@ class HandlerConfig:
 
         if self.required_args is not None:
             for name, ra in self.required_args.items():
-                hints["required-args"][name] = ra.method_spec().dictify()
+                hints["required-args"][name] = ra.method_spec()
 
         return hints
 

--- a/examples/opup/contract.py
+++ b/examples/opup/contract.py
@@ -1,7 +1,6 @@
 from pyteal import *
-from typing import Literal
 from beaker.contracts import OpUp
-from beaker.decorators import bare_handler, handler
+from beaker.decorators import required_args, handler
 
 
 class ExpensiveApp(OpUp):
@@ -14,6 +13,7 @@ class ExpensiveApp(OpUp):
         )
 
     @handler
+    @required_args(opup_app=OpUp.get_opup_app_id)
     def hash_it(
         input: abi.String,
         iters: abi.Uint64,
@@ -37,4 +37,5 @@ class ExpensiveApp(OpUp):
 if __name__ == "__main__":
 
     ea = ExpensiveApp()
-    print(ea.approval_program)
+    print(ea.contract_hints())
+    # print(ea.approval_program)

--- a/examples/opup/main.py
+++ b/examples/opup/main.py
@@ -5,7 +5,8 @@ from algosdk.atomic_transaction_composer import (
 )
 from algosdk.future import transaction
 
-from beaker import ApplicationClient, method_spec
+from beaker import method_spec
+from beaker.client import ApplicationClient
 from beaker.sandbox import get_client, get_accounts
 
 from contract import ExpensiveApp


### PR DESCRIPTION
With the requirement that the caller pass what they intend to "touch", it'd be helpful to offer some way to denote how certain required arguments may be discovered.

Here we're adding a hint to discover the required input by marking an argument as required and providing the ABI method to call to produce the expected argument.

Currently in order to automatically resolve the required argument, the user of the `call` method on an `ApplicationClient` may pass `None` as an element of the `args` array. This will cause the `ApplicationClient` to check for hints and if one is defined, call the method and replace its output with the `None` value.

This design may not be the best but I think the problem of knowing information to make a successful call is real.  I think it could be addressed to some degree automatically. wdyt?