### PR TITLE
Add `get_account_info` function for contracts

### DIFF
--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -38,7 +38,7 @@ class ApplicationClient:
         self.client = client
         self.app = app
         self.app_id = app_id
-        self.app_addr = None
+        self.app_addr = get_application_address(app_id) if self.app_id != 0 else None
 
         self.signer = signer
         self.sender = sender
@@ -413,11 +413,10 @@ class ApplicationClient:
         return decode_state(
             acct_state["app-local-state"]["key-value"], force_str=force_str
         )
-    
+
     def get_account_info(self) -> dict[str, Any]:
         app_state = self.client.get_account_info(self.app_addr)
         return app_state
-    
 
     def resolve(self, to_resolve):
         if ResolvableTypes.Constant in to_resolve:

--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -38,6 +38,7 @@ class ApplicationClient:
         self.client = client
         self.app = app
         self.app_id = app_id
+        self.app_addr = None
 
         self.signer = signer
         self.sender = sender
@@ -101,6 +102,7 @@ class ApplicationClient:
         app_addr = get_application_address(app_id)
 
         self.app_id = app_id
+        self.app_addr = app_addr
 
         return app_id, app_addr, create_txid
 
@@ -411,6 +413,11 @@ class ApplicationClient:
         return decode_state(
             acct_state["app-local-state"]["key-value"], force_str=force_str
         )
+    
+    def get_account_info(self) -> dict[str, Any]:
+        app_state = self.client.get_account_info(self.app_addr)
+        return app_state
+    
 
     def resolve(self, to_resolve):
         if ResolvableTypes.Constant in to_resolve:


### PR DESCRIPTION
This commit adds the ability to query a contract's account info
programmatically in a clean manner. This aims for all functions
pertaining to a contract be directly callable from the `ApplicationClient`
class.