### PR TITLE
adding logic error parsing

### DIFF
--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -523,7 +523,7 @@ class ApplicationClient:
         line_no = self.approval_src_map.get_line_for_pc(pc)
         approval_lines = self.app.approval_program.split("\n")
         approval_lines[line_no] += " <-- This one right here was where we failed"
-        joined = "\n\t".join(approval_lines[line_no-5:line_no+5])
+        joined = "\n\t".join(approval_lines[line_no - 5 : line_no + 5])
 
         return f"Tx: {txid} had logic error at pc {pc} and source line {line_no}: \n\t{joined}"
 

--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -523,9 +523,9 @@ class ApplicationClient:
         line_no = self.approval_src_map.get_line_for_pc(pc)
         approval_lines = self.app.approval_program.split("\n")
         approval_lines[line_no] += " <-- This one right here was where we failed"
-        joined = "\n".join(approval_lines[line_no-5:line_no+5])
+        joined = "\n\t".join(approval_lines[line_no-5:line_no+5])
 
-        return f"Tx: {txid} had logic error at pc {pc} and source line {line_no}: \n{joined}"
+        return f"Tx: {txid} had logic error at pc {pc} and source line {line_no}: \n\t{joined}"
 
     def get_sender(self, sender: str = None, signer: TransactionSigner = None) -> str:
         if sender is not None:

--- a/beaker/client/logic_error.py
+++ b/beaker/client/logic_error.py
@@ -1,0 +1,9 @@
+import re
+
+ASSERT_ERROR_PATTERN = "TransactionPool.Remember: transaction ([A-Z0-9]*): logic eval error: assert failed pc=(\d+). Details: pc=(\d+), opcodes=.*"
+
+def parse_logic_error(error_str: str) -> tuple[str, int]:
+    matches = re.match(ASSERT_ERROR_PATTERN, error_str)
+    txid = matches.group(1)
+    pc = int(matches.group(2))
+    return txid, pc

--- a/beaker/client/logic_error.py
+++ b/beaker/client/logic_error.py
@@ -1,6 +1,7 @@
 import re
 
-ASSERT_ERROR_PATTERN = "TransactionPool.Remember: transaction ([A-Z0-9]*): logic eval error: assert failed pc=(\d+). Details: pc=(\d+), opcodes=.*"
+ASSERT_ERROR_PATTERN = "TransactionPool.Remember: transaction ([A-Z0-9]+): logic eval error: assert failed pc=([0-9]+). Details: pc=([0-9]+), opcodes=.*"
+
 
 def parse_logic_error(error_str: str) -> tuple[str, int]:
     matches = re.match(ASSERT_ERROR_PATTERN, error_str)

--- a/examples/client/client.py
+++ b/examples/client/client.py
@@ -18,7 +18,7 @@ class ClientExample(Application):
     )
 
     nickname: Final[AccountStateValue] = AccountStateValue(
-        stack_type=TealType.bytes, descr="what this uers prefers to be called"
+        stack_type=TealType.bytes, descr="what this user prefers to be called"
     )
 
     @external(authorize=Authorize.only(manager))

--- a/examples/client/client.py
+++ b/examples/client/client.py
@@ -73,7 +73,9 @@ def demo():
         app_client2.call(app.set_manager, new_manager=addr2)
         print("Shouldn't get here")
     except Exception as e:
+        print()
         print(app_client2.parse_logic_error(str(e)))
+        print()
         print("Failed as expected, only addr1 should be authorized to set the manager")
 
     # Have addr1 set the manager to addr2

--- a/examples/client/client.py
+++ b/examples/client/client.py
@@ -72,7 +72,8 @@ def demo():
     try:
         app_client2.call(app.set_manager, new_manager=addr2)
         print("Shouldn't get here")
-    except Exception:
+    except Exception as e:
+        print(app_client2.parse_logic_error(str(e)))
         print("Failed as expected, only addr1 should be authorized to set the manager")
 
     # Have addr1 set the manager to addr2

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -6,7 +6,7 @@ msgpack==1.0.4
 mypy-extensions==0.4.3
 pathspec==0.9.0
 platformdirs==2.5.2
-py-algorand-sdk==1.15.0
+py-algorand-sdk==1.16.0
 pycparser==2.21
 pycryptodomex==3.15.0
 PyNaCl==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ msgpack==1.0.4
 mypy-extensions==0.4.3
 pathspec==0.9.0
 platformdirs==2.5.2
-py-algorand-sdk==1.15.0
+py-algorand-sdk==1.16.0
 pycparser==2.21
 pycryptodomex==3.15.0
 PyNaCl==1.5.0


### PR DESCRIPTION
```
~/beaker/examples/client$ python client.py
{'nickname': 'first'}
{'nickname': 'second'}
Current app state: {'manager': '0xdb48492f1ea169a9a5c7200a039675f0cad0bf5481f784f4b5dd4f35878d253e'}

Tx: I3BF7D2UYDMJFC3IYPH3NEC4552GO6BOMLLI3752KRHEJITISAEA had logic error at pc 212 and source line 147: 
        // set_manager
        setmanager_6:
        store 0
        txn Sender
        callsub authonly_5
        assert <-- This one right here was where we failed
        bytec_0 // "manager"
        load 0
        app_global_put
        retsub

Failed as expected, only addr1 should be authorized to set the manager
Current app state: {'manager': '0xaee1fb894b901f19563cad2886835c98372b5a1e5afed9ab1468e97a0bbbb064'}
Current app state: {'manager': '0xdb48492f1ea169a9a5c7200a039675f0cad0bf5481f784f4b5dd4f35878d253e'}
```


Need something like this to map back to original pyteal https://github.com/algorand/pyteal/pull/447