### PR TITLE
Minor improvement in `requirements.txt` for missing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ __pycache__/
 .coverage
 docs/build/
 dist/*
-.mypy-cache/*
+.mypy-cache/
+.idea/
 
 # Pyenv
 .python-version

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 setup-development:
 	pip install -e .
-	pip install -r requirements.txt
+	pip install -r requirements.txt --upgrade
 
 setup-wheel:
 	pip install wheel
@@ -22,7 +22,7 @@ black:
 flake8:
 	flake8 $(ALLPY)
 
-MYPY = beaker 
+MYPY = beaker
 mypy:
 	mypy --show-error-codes $(MYPY)
 
@@ -32,13 +32,13 @@ lint: black flake8 mypy
 # ---- Tests ---- #
 
 tests:
-	pytest beaker 
+	pytest beaker
 
 lint-and-test: lint tests
 
 # ---- Integration Tests (algod required) ---- #
 
-all-tests: lint-and-test 
+all-tests: lint-and-test
 
 # ---- Local Github Actions Simulation via `act` ---- #
 # assumes act is installed, e.g. via `brew install act`

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pytest==7.1.2
 flake8==4.0.1
 mypy==0.971
 mypy-extensions==0.4.3
+numpy>=1.23.0


### PR DESCRIPTION
The new added dependency `numpy` is for `examples/amm/constant_product_amm.py`.

Does not get into runtime of `breaker`, so add dependency into `requirements.txt`.