### PR TITLE
Run AMM tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: black flake8 mypy
 # ---- Tests ---- #
 
 tests:
-	pytest beaker
+	pytest beaker examples/amm
 
 lint-and-test: lint tests
 


### PR DESCRIPTION
While considering other changes, I observed a failing test and then noticed AMM tests are _not_ part of the build.  The PR suggests a failing test fix + adds AMM tests to the build.

Here's the error from a failing test:  ` algosdk.error.AlgodHTTPError: TransactionPool.Remember: transaction AYNST2OPTMHB2PGPDXRBLOIZCIOT22U23J6ROBCQHLHIM5QPF3FA: logic eval error: fee too small`.