### PR TITLE
Missing DeleteApplicationOC in ApplicationClient

### DIFF
--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -394,6 +394,7 @@ class ApplicationClient:
             self.add_method_call(
                 atc,
                 self.app.on_delete,
+                on_complete=transaction.OnComplete.DeleteApplicationOC,
                 sender=sender,
                 sp=sp,
                 index=self.app_id,


### PR DESCRIPTION
The `on_complete` field seems to be missing in the `add_method_call` of the `delete` decorator.