### PR TITLE
Refr: Redundancy in variable name

### DIFF
--- a/examples/c2c/main.py
+++ b/examples/c2c/main.py
@@ -181,7 +181,7 @@ def demo():
         suggested_params=sp,
     )
     created_asset = result.return_value
-    print(f"Created asset id: {result.return_value}")
+    print(f"Created asset id: {created_asset}")
 
     result = app_client_main.call(
         C2CMain.delete_asset,


### PR DESCRIPTION
created_asset already references result.return_value so no need to use it again

examples main file in the demo section