### PR TITLE
fix typo in precompile.py docstring for AppPrecompile

### DIFF
--- a/beaker/precompile.py
+++ b/beaker/precompile.py
@@ -250,7 +250,7 @@ class AppPrecompile:
         self.clear: Precompile = Precompile("")
 
     def compile(self, client: AlgodClient):
-        """fully compile this lsig precompile by recursively compiling children depth first
+        """fully compile this app precompile by recursively compiling children depth first
 
         Note:
             Must be called (even indirectly) prior to using the ``approval`` and ``clear`` fields


### PR DESCRIPTION
Fixing the little typo in the docs since I think the online doc gets also generated from it. Greetings