### PR TITLE
added comment on default read for account state

### DIFF
--- a/examples/state/contract.py
+++ b/examples/state/contract.py
@@ -114,6 +114,8 @@ class StateExample(Application):
 
     @external(read_only=True)
     def get_account_state_val(self, *, output: abi.Uint64):
+        # If read account state without bracket specifying specific account,
+        # defaults to Txn.Sender()
         return output.set(self.declared_account_value[Txn.sender()])
 
     @external


### PR DESCRIPTION
The Beaker doc did not mention that you can do
`self.some_account_state.get()`
to get the account state for the transaction sender. 

Added comments in the full example code for States. 