### PR TITLE
Properly handle "action" and "type" keys in decode_state

### DIFF
--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -688,7 +688,11 @@ class ApplicationClient:
         app_state = self.client.application_info(self.app_id)
         if "params" not in app_state or "global-state" not in app_state["params"]:
             return {}
-        return decode_state(app_state["params"]["global-state"], raw=raw)
+
+        return cast(
+            dict[bytes | str, bytes | str | int],
+            decode_state(app_state["params"]["global-state"], raw=raw),
+        )
 
     def get_account_state(
         self, account: str = None, raw: bool = False
@@ -706,7 +710,10 @@ class ApplicationClient:
         ):
             return {}
 
-        return decode_state(acct_state["app-local-state"]["key-value"], raw=raw)
+        return cast(
+            dict[str | bytes, bytes | str | int],
+            decode_state(acct_state["app-local-state"]["key-value"], raw=raw),
+        )
 
     def get_application_account_info(self) -> dict[str, Any]:
         """gets the account info for the application account"""

--- a/beaker/client/state_decode.py
+++ b/beaker/client/state_decode.py
@@ -25,12 +25,18 @@ def decode_state(
         key: str | bytes = raw_key if raw else str_or_hex(raw_key)
         val: str | bytes | int
 
-        match sv["value"]["type"]:
+        action = (
+            sv["value"]["action"] if "action" in sv["value"] else sv["value"]["type"]
+        )
+
+        match action:
             case 1:
                 raw_val = b64decode(sv["value"]["bytes"])
                 val = raw_val if raw else str_or_hex(raw_val)
             case 2:
                 val = sv["value"]["uint"]
+            case 3:
+                val = None
 
         decoded_state[key] = val
     return decoded_state

--- a/beaker/client/state_decode.py
+++ b/beaker/client/state_decode.py
@@ -14,16 +14,16 @@ def str_or_hex(v: bytes) -> str:
 
 def decode_state(
     state: list[dict[str, Any]], raw=False
-) -> dict[str | bytes, bytes | str | int]:
+) -> dict[str | bytes, bytes | str | int | None]:
 
-    decoded_state: dict[str | bytes, bytes | str | int] = {}
+    decoded_state: dict[str | bytes, bytes | str | int | None] = {}
 
     for sv in state:
 
         raw_key = b64decode(sv["key"])
 
         key: str | bytes = raw_key if raw else str_or_hex(raw_key)
-        val: str | bytes | int
+        val: str | bytes | int | None
 
         action = (
             sv["value"]["action"] if "action" in sv["value"] else sv["value"]["type"]


### PR DESCRIPTION
Properly decode state when the input uses the `action` key. Also sets the value to `None` when state is deleted. 