### PR TITLE
Install flake8-tidy-imports so existing rules are respected

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,7 +17,7 @@ exclude =
     examples
 
 per-file-ignores =
-    */__init__.py:          F401
+    */__init__.py:          F401 I252
 
 # from flake8-tidy-imports
 ban-relative-imports = true

--- a/beaker/lib/math/math.py
+++ b/beaker/lib/math/math.py
@@ -23,7 +23,7 @@ from pyteal import (
     TealType,
 )
 
-from ..inline.inline_asm import InlineAssembly
+from beaker.lib.inline import InlineAssembly
 
 _scale = 1000000
 _log2_10 = math.log2(10)

--- a/beaker/lib/strings/string.py
+++ b/beaker/lib/strings/string.py
@@ -20,7 +20,7 @@ from pyteal import (
     TealType,
 )
 
-from ..math import pow10
+from beaker.lib.math import pow10
 
 # Magic number to convert between ascii chars and integers
 _ascii_zero = 48

--- a/poetry.lock
+++ b/poetry.lock
@@ -250,6 +250,17 @@ pycodestyle = ">=2.10.0,<2.11.0"
 pyflakes = ">=3.0.0,<3.1.0"
 
 [[package]]
+name = "flake8-tidy-imports"
+version = "4.8.0"
+description = "A flake8 plugin that helps you write tidier imports."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+flake8 = ">=3.8.0"
+
+[[package]]
 name = "fonttools"
 version = "4.38.0"
 description = "Tools to manipulate font files"
@@ -921,7 +932,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "73385561f728270af9b51021284ceb1a563937d5e579b49666027a037e3f70c1"
+content-hash = "fd871139dac6aa780d21ca514f969c424d1f417f604888ee59995abb42582e04"
 
 [metadata.files]
 aiohttp = [
@@ -1283,6 +1294,10 @@ filelock = [
 flake8 = [
     {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
     {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
+]
+flake8-tidy-imports = [
+    {file = "flake8-tidy-imports-4.8.0.tar.gz", hash = "sha256:df44f9c841b5dfb3a7a1f0da8546b319d772c2a816a1afefcce43e167a593d83"},
+    {file = "flake8_tidy_imports-4.8.0-py3-none-any.whl", hash = "sha256:25bd9799358edefa0e010ce2c587b093c3aba942e96aeaa99b6d0500ae1bf09c"},
 ]
 fonttools = [
     {file = "fonttools-4.38.0-py3-none-any.whl", hash = "sha256:820466f43c8be8c3009aef8b87e785014133508f0de64ec469e4efb643ae54fb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ mypy = "0.982"
 black = {extras = ["d"], version = "^22.12.0"}
 pytest-cov = "^4.0.0"
 pre-commit = "^2.20.0"
+flake8-tidy-imports = "^4.8.0"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "~5.0.2"

--- a/tests/math_test.py
+++ b/tests/math_test.py
@@ -5,7 +5,7 @@ import beaker as bkr
 
 from beaker.testing.unit_testing_helpers import UnitTestingApp, assert_output
 
-import beaker.lib.math as math
+from beaker.lib import math
 
 
 def test_even():


### PR DESCRIPTION
There is a line in `.flake8` to ban relative imports, but relatives imports exist in the code base. Fix this by installing the flake8 plugin and fixing the issues it found. Ignoring in `__init__.py` files for now.