### PR TITLE
remove references to future package

### DIFF
--- a/beaker/application.py
+++ b/beaker/application.py
@@ -252,7 +252,7 @@ class Application:
         if self.approval_program is not None and self.clear_program is not None:
             return self.approval_program, self.clear_program
 
-        if len(self.precompiles) > 0:
+        if len(self.precompiles) > 0 and client is not None:
             # make sure all the precompiles are available
             for precompile in self.precompiles.values():
                 precompile.compile(client)

--- a/beaker/client/api_providers.py
+++ b/beaker/client/api_providers.py
@@ -82,10 +82,12 @@ class PureStake(APIProvider):
     def algod(self, token: str = "") -> AlgodClient:
         algod_client = super().algod()
         algod_client.headers = {self.token_header: token}
+        return algod_client
 
     def indexer(self, token: str = "") -> IndexerClient:
-        indexer_client = super().algod()
+        indexer_client = super().indexer()
         indexer_client.headers = {self.token_header: token}
+        return indexer_client
 
 
 class Sandbox(APIProvider):

--- a/beaker/client/application_client.py
+++ b/beaker/client/application_client.py
@@ -64,12 +64,12 @@ class ApplicationClient:
 
     def compile(
         self, teal: str, source_map: bool = False
-    ) -> tuple[bytes, str, Optional[SourceMap]]:
+    ) -> tuple[bytes, str, SourceMap | None]:
         result = self.client.compile(teal, source_map=source_map)
         src_map = None
         if source_map:
             src_map = SourceMap(result["sourcemap"])
-        return (b64decode(result["result"]), cast(str, result["hash"]), src_map)
+        return b64decode(result["result"]), cast(str, result["hash"]), src_map
 
     def build(self) -> None:
         """
@@ -494,9 +494,6 @@ class ApplicationClient:
             **kwargs,
         )
 
-        if atc is None:
-            raise Exception("No ATC was built?")
-
         # If its a read-only method, use dryrun (TODO: swap with simulate later?)
         if hints.read_only:
             dr_req = transaction.create_dryrun(self.client, atc.gather_signatures())
@@ -599,7 +596,7 @@ class ApplicationClient:
         lease: bytes | None = None,
         rekey_to: str | None = None,
         **kwargs,
-    ):
+    ) -> AtomicTransactionComposer:
 
         """Adds a transaction to the AtomicTransactionComposer passed"""
 
@@ -668,7 +665,7 @@ class ApplicationClient:
         self, atc: AtomicTransactionComposer, txn: transaction.Transaction
     ) -> AtomicTransactionComposer:
         if self.signer is None:
-            raise Exception("Cannot add transaction without signer being set")
+            raise ValueError("Cannot add transaction without signer being set")
         atc.add_transaction(TransactionWithSigner(txn=txn, signer=self.signer))
         return atc
 

--- a/beaker/client/logic_error.py
+++ b/beaker/client/logic_error.py
@@ -38,6 +38,8 @@ class LogicException(Exception):
         return f"Txn {self.txid} had error '{self.msg}' at PC {self.pc} and Source Line {self.line_no}: \n\n\t{self.trace()}"
 
     def trace(self, lines: int = 5) -> str:
+        if self.line_no is None:
+            self.line_no = 0
         program_lines = copy(self.lines)
         program_lines[self.line_no] += "\t\t<-- Error"
         lines_before = max(0, self.line_no - lines)

--- a/beaker/precompile.py
+++ b/beaker/precompile.py
@@ -381,7 +381,7 @@ class LSigPrecompile:
         It should only be used for non templated Precompiles.
         """
         if self.logic._binary is None:
-            raise Exception("Cannot provide a signer for Lsig with no binary")
+            raise ValueError("Cannot provide a signer for Lsig with no binary")
         return LogicSigTransactionSigner(LogicSigAccount(self.logic._binary))
 
 

--- a/beaker/precompile.py
+++ b/beaker/precompile.py
@@ -22,7 +22,7 @@ from pyteal import (
 )
 from algosdk.v2client.algod import AlgodClient
 from algosdk.source_map import SourceMap
-from algosdk.future.transaction import LogicSigAccount
+from algosdk.transaction import LogicSigAccount
 from algosdk.constants import APP_PAGE_MAX_SIZE
 from algosdk.atomic_transaction_composer import LogicSigTransactionSigner
 from beaker.consts import PROGRAM_DOMAIN_SEPARATOR, num_extra_program_pages
@@ -127,7 +127,7 @@ class Precompile:
         self.binary = Bytes(self._binary)
         for tv in self._template_values:
             # +1 to acount for the pushbytes/pushint op
-            tv.pc = self._map.get_pcs_for_line(tv.line)[0] + 1
+            tv.pc = self._map.get_pcs_for_line(tv.line)[0] + 1  # type: ignore[index]
 
         def _hash_program(data: bytes) -> bytes:
             """compute the hash"""
@@ -380,6 +380,8 @@ class LSigPrecompile:
 
         It should only be used for non templated Precompiles.
         """
+        if self.logic._binary is None:
+            raise Exception("Cannot provide a signer for Lsig with no binary")
         return LogicSigTransactionSigner(LogicSigAccount(self.logic._binary))
 
 
@@ -399,7 +401,7 @@ def _gather_asserts(program: str, src_map: SourceMap) -> dict[int, ProgramAssert
         if line != "assert":
             continue
 
-        pc = src_map.get_pcs_for_line(idx)[0]
+        pc = src_map.get_pcs_for_line(idx)[0]  # type: ignore [index]
 
         # TODO: this will be wrong for multiline comments
         line_before = program_lines[idx - 1]

--- a/beaker/state.py
+++ b/beaker/state.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 from copy import copy
 from typing import Callable, Mapping, cast, Any, Optional
-from algosdk.future.transaction import StateSchema
+from algosdk.transaction import StateSchema
 from pyteal import (
     abi,
     SubroutineFnWrapper,

--- a/beaker/testing/unit_testing_helpers.py
+++ b/beaker/testing/unit_testing_helpers.py
@@ -105,9 +105,9 @@ def assert_output(
             if opups > 0:
                 atc = AtomicTransactionComposer()
 
-                app_client.add_method_call(atc, app.unit_test, **input)
+                app_client.add_method_call(atc, app.unit_test, **input)  # type: ignore
                 for x in range(opups):
-                    app_client.add_method_call(atc, app.opup, note=str(x).encode())
+                    app_client.add_method_call(atc, app.opup, note=str(x).encode())  # type: ignore
 
                 try:
                     results = atc.execute(algod_client, 2)
@@ -116,7 +116,7 @@ def assert_output(
 
                 assert results.abi_results[0].return_value == output
             else:
-                result = app_client.call(app.unit_test, **input)
+                result = app_client.call(app.unit_test, **input)  # type: ignore
                 assert result.return_value == output
     except Exception as e:
         raise e

--- a/examples/account_storage/main.py
+++ b/examples/account_storage/main.py
@@ -1,7 +1,7 @@
 import random
 import string
 from typing import cast
-import algosdk.future.transaction as txns
+import algosdk.transaction as txns
 from algosdk.atomic_transaction_composer import *
 from pyteal import *
 from beaker import *

--- a/examples/amm/amm_test.py
+++ b/examples/amm/amm_test.py
@@ -10,7 +10,7 @@ from algosdk.atomic_transaction_composer import (
     AccountTransactionSigner,
     abi,
 )
-from algosdk.future import transaction
+from algosdk import transaction
 from algosdk.v2client.algod import AlgodClient
 from algosdk.encoding import decode_address
 from beaker import client, sandbox, testing, consts, decorators

--- a/examples/boxen/main.py
+++ b/examples/boxen/main.py
@@ -1,7 +1,7 @@
 from algosdk.abi import ABIType
 from algosdk.encoding import encode_address, decode_address
 from algosdk.atomic_transaction_composer import TransactionWithSigner
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 from pyteal import *
 from beaker import *

--- a/examples/offload_compute/main.py
+++ b/examples/offload_compute/main.py
@@ -4,7 +4,7 @@ from algosdk.atomic_transaction_composer import (
     AtomicTransactionComposer,
     TransactionWithSigner,
 )
-from algosdk.future.transaction import *
+from algosdk.transaction import *
 
 from pyteal import *
 from beaker import *

--- a/examples/opup/main.py
+++ b/examples/opup/main.py
@@ -2,7 +2,7 @@ from hashlib import sha256
 from algosdk.atomic_transaction_composer import (
     TransactionWithSigner,
 )
-from algosdk.future import transaction
+from algosdk import transaction
 
 from beaker.client import ApplicationClient
 from beaker.consts import milli_algo

--- a/examples/templated_lsig/main.py
+++ b/examples/templated_lsig/main.py
@@ -3,7 +3,7 @@ from copy import copy
 from nacl.signing import SigningKey
 
 from algosdk.encoding import decode_address
-from algosdk.future import transaction
+from algosdk import transaction
 from algosdk.atomic_transaction_composer import (
     AtomicTransactionComposer,
     TransactionWithSigner,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.10"
 pyteal = "~0.20.1"
+# TODO: reminder to change this 
 py-algorand-sdk = ">=1.16.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/client/application_client_test.py
+++ b/tests/client/application_client_test.py
@@ -5,7 +5,7 @@ from base64 import b64decode, b64encode
 
 from algosdk.account import generate_account
 from algosdk.logic import get_application_address
-from algosdk.future.transaction import Multisig, LogicSigAccount, OnComplete
+from algosdk.transaction import Multisig, LogicSigAccount, OnComplete
 from algosdk.atomic_transaction_composer import (
     AtomicTransactionComposer,
     AccountTransactionSigner,


### PR DESCRIPTION
prep for sdk 2.0 w/ breaking changes: https://github.com/algorand/py-algorand-sdk/pull/422 

also added some `type: ignore` comments, at some point before release these should be actually fixed 

