### PR TITLE
add internal flag to handler config to prevent exposing internal methods

### DIFF
--- a/beaker/application.py
+++ b/beaker/application.py
@@ -183,7 +183,7 @@ class Application:
                     self.bare_externals[oc] = action
 
             # ABI externals
-            elif handler_config.method_spec is not None:
+            elif handler_config.method_spec is not None and not handler_config.internal:
                 # Create the ABIReturnSubroutine from the static attr
                 # but override the implementation with the bound version
                 abi_meth = ABIReturnSubroutine(
@@ -255,7 +255,7 @@ class Application:
         if len(self.precompiles) > 0:
             # make sure all the precompiles are available
             for precompile in self.precompiles.values():
-                precompile.compile(client)
+                precompile.compile(client)  # type: ignore
 
         self.router = Router(
             name=self.__class__.__name__,

--- a/beaker/decorators.py
+++ b/beaker/decorators.py
@@ -125,9 +125,9 @@ class HandlerConfig:
     default_arguments: Optional[dict[str, DefaultArgument]] = field(
         kw_only=True, default=None
     )
-
     method_config: Optional[MethodConfig] = field(kw_only=True, default=None)
     read_only: bool = field(kw_only=True, default=False)
+    internal: bool = field(kw_only=True, default=False)
 
     def hints(self) -> "MethodHints":
         mh: dict[str, Any] = {"read_only": self.read_only}
@@ -414,7 +414,7 @@ def internal(
         fn = cast(HandlerFunc, return_type_or_handler)
 
     def _impl(fn: HandlerFunc) -> HandlerFunc:
-
+        set_handler_config(fn, internal=True)
         if return_type is not None:
             set_handler_config(fn, subroutine=Subroutine(return_type, name=fn.__name__))
 

--- a/tests/application_test.py
+++ b/tests/application_test.py
@@ -87,6 +87,20 @@ def test_single_external():
         sh.contract.get_method_by_name("made up")
 
 
+def test_internal_not_exposed():
+    class SingleInternal(Application):
+        @external
+        def doit(self, *, output: pt.abi.Bool):
+            return self.do_permissioned_thing(output=output)
+
+        @internal
+        def do_permissioned_thing(self, *, output: pt.abi.Bool):
+            return pt.Seq((b := pt.abi.Bool()).set(pt.Int(1)), output.set(b))
+
+    si = SingleInternal()
+    assert len(si.methods) == 1, "Expected a single external"
+
+
 def test_method_override():
     class MethodOverride(Application):
         @external(name="handle")


### PR DESCRIPTION
internal methods were getting exposed in the ABI