### PR TITLE
fix: rename Application version parameter to teal_version

### DIFF
--- a/beaker/application.py
+++ b/beaker/application.py
@@ -1,6 +1,7 @@
 import base64
 from inspect import getattr_static
 from typing import Final, Any, cast, Optional
+from warnings import warn
 from algosdk.v2client.algod import AlgodClient
 from algosdk.abi import Method
 from pyteal import (
@@ -69,9 +70,19 @@ class Application:
     address: Final[Expr] = Global.current_application_address()
     id: Final[Expr] = Global.current_application_id()
 
-    def __init__(self, version: int = MAX_TEAL_VERSION):
+    def __init__(
+        self, teal_version: int = MAX_TEAL_VERSION, version: int | None = None
+    ):
         """Initialize the Application, finding all the custom attributes and initializing the Router"""
-        self.teal_version = version
+        if version is not None:
+            warn(
+                "version is deprecated, please use teal_version instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.teal_version = version
+        else:
+            self.teal_version = teal_version
 
         # Get initial list of all attrs declared
         initial_attrs = {

--- a/tests/application_test.py
+++ b/tests/application_test.py
@@ -1,5 +1,6 @@
 import pytest
 from typing import Final, cast
+from warnings import catch_warnings
 from dataclasses import asdict
 from Cryptodome.Hash import SHA512
 import pyteal as pt
@@ -64,10 +65,28 @@ def test_teal_version():
     class EmptyApp(Application):
         pass
 
-    ea = EmptyApp(version=4)
+    ea = EmptyApp(teal_version=4)
 
     assert ea.teal_version == 4, "Expected teal v4"
     assert ea.approval_program.split("\n")[0] == "#pragma version 4"
+
+
+def test_version_deprecation():
+    class EmptyApp(Application):
+        pass
+
+    with catch_warnings(record=True) as warnings:
+        assert len(warnings) == 0
+
+        ea = EmptyApp(version=4)
+
+        assert len(warnings) == 1
+        assert (
+            str(warnings[0].message)
+            == "version is deprecated, please use teal_version instead"
+        )
+        assert ea.teal_version == 4, "Expected teal v4"
+        assert ea.approval_program.split("\n")[0] == "#pragma version 4"
 
 
 def test_single_external():


### PR DESCRIPTION
version parameter will still work for now, but gives a deprecation warning