### PR TITLE
Fixing typo in usage.rst

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -16,7 +16,7 @@ First, create a class to represent our application as a subclass of the beaker `
 
 .. code-block:: python
 
-    beaker.application import Application
+    from beaker.application import Application
 
     class Calculator(Application):
         pass 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -16,7 +16,7 @@ First, create a class to represent our application as a subclass of the beaker `
 
 .. code-block:: python
 
-    from beaker import Application
+    beaker.application import Application
 
     class Calculator(Application):
         pass 


### PR DESCRIPTION
## Proposed changes

- Tiny typo fix with import statement, application client doesn't seem to be available under beaker anymore, hence the change